### PR TITLE
add separate no op actions for merge to main

### DIFF
--- a/.github/workflows/REPO_MERGED_WORKFLOW.yaml
+++ b/.github/workflows/REPO_MERGED_WORKFLOW.yaml
@@ -1,0 +1,18 @@
+name: FXTrading-Merge-To-Main-Workflow
+
+on:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  OnMainMerge:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+    - name: echo hello
+      run: |
+        echo "Hello! This will do more when release actions on a PR merge are needed."
+

--- a/.github/workflows/REPO_PR_WORKFLOW.yaml
+++ b/.github/workflows/REPO_PR_WORKFLOW.yaml
@@ -1,10 +1,10 @@
-name: FXTrading-Repo-Workflow
+name: FXTrading-PR-Workflow
 
 on:
   pull_request:
     branches:
       - 'main'
-    types: [synchronize, reopened, closed, opened]
+    types: [synchronize, reopened, opened]
 
 permissions:
   id-token: write


### PR DESCRIPTION
There is no need to waste GHA time by running linting and tests for things that passed before merging.